### PR TITLE
use Date::toLocaleString() to display amas' "create_at" attribute

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,7 +14,7 @@ fetch('https://api.github.com/repos/vim-tw/ama/issues').then(function(response) 
     var content = '';
     amas.forEach(function(ama, index, array) {
         if (ama.pull_request !== undefined){return;}
-        content += `<li><a href="${ama.html_url}">${ama.title}</a> <small>from ${ama.created_at}</small></li>`;
+        content += `<li><a href="${ama.html_url}">${ama.title}</a> <small>from ${(new Date(ama.created_at).toLocaleString())}</small></li>`;
     });
     return content;
 })


### PR DESCRIPTION
The original format for displaying amas' "create_at" attribute is not user friendly, so I tried to make it displayed with foramt corresponding to browser's locale.
